### PR TITLE
Feature/update to work with WPGraphQL 0.2.0

### DIFF
--- a/src/QueryTrace.php
+++ b/src/QueryTrace.php
@@ -17,29 +17,6 @@ class QueryTrace {
 	protected static $trace = [];
 
 	/**
-	 * QueryTrace constructor.
-	 * @access public
-	 */
-	public function __construct() {
-
-		if ( ! defined( 'SAVEQUERIES' ) ) {
-			define( 'SAVEQUERIES', true );
-		}
-
-		if ( ! defined( 'QM_DB_EXPENSIVE' ) ) {
-			define( 'QM_DB_EXPENSIVE', 0.05 );
-		}
-
-		/**
-		 * Enable Core WordPress query logging
-		 */
-		if ( SAVEQUERIES && property_exists( $GLOBALS['wpdb'], 'save_queries' ) ) {
-			$GLOBALS['wpdb']->save_queries = true;
-		}
-
-	}
-
-	/**
 	 * Initialize the trace if SAVEQUERIES is enabled
 	 * @access public
 	 */

--- a/src/Tracing.php
+++ b/src/Tracing.php
@@ -1,8 +1,6 @@
 <?php
 
 namespace WPGraphQL\Extensions\Insights;
-use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
 
 /**
  * Class Tracing
@@ -16,11 +14,6 @@ class Tracing {
 	 * @var array
 	 */
 	protected static $field_resolver_trace = [];
-
-	/**
-	 * Stores whether tracing should be included in the response for GraphQL Requests
-	 */
-	public static $include_in_response = true;
 
 	/**
 	 * Stores whether tracing is enabled or not
@@ -96,21 +89,6 @@ class Tracing {
 		$timestamp = \DateTime::createFromFormat( 'U.u', $time );
 
 		return $timestamp->format( "Y-m-d\TH:i:s.uP" );
-	}
-
-	/**
-	 * @param array  $results        The results of a GraphQL request
-	 * @param object $schema         The Schema for the GraphQL request
-	 * @param string $operation_name The name of the GraphQL operation
-	 * @param array  $request        The incoming request
-	 * @param array  $variables      The variables for the request
-	 *
-	 * @return bool
-	 */
-	protected static function include_tracing_in_response( $results, $schema, $operation_name, $request, $variables ) {
-		$include = apply_filters( 'graphql_insights_include_tracing_in_response', true, $results, $schema, $operation_name, $request, $variables );
-
-		return $include;
 	}
 
 	/**
@@ -284,7 +262,7 @@ class Tracing {
 		 * @param string $request
 		 * @param array $variables
 		 */
-		$include_in_response = apply_filters( 'graphql_tracing_include_in_response', self::$include_in_response, $response, $schema, $operation_name, $request, $variables );
+		$include_in_response = apply_filters( 'graphql_tracing_include_in_response', true, $response, $schema, $operation_name, $request, $variables );
 
 		if ( true !== $include_in_response ) {
 			return $response;
@@ -294,7 +272,7 @@ class Tracing {
 		 * If tracing should be included in the response
 		 */
 		if ( ! empty( $response ) ) {
-			if( is_array( $response ) ) {
+			if ( is_array( $response ) ) {
 				$response['extensions']['tracing'] = self::get_trace();
 			} else if ( is_object( $response ) ) {
 				$response->extensions['tracing'] = self::get_trace();
@@ -320,6 +298,21 @@ class Tracing {
 	 */
 	public static function add_tracked_queries_to_response_extensions( $response, $schema, $operation_name, $request, $variables ) {
 
+		/**
+		 * Filter whether the queryLog should be included in the response or not.
+		 *
+		 * @param bool $include_in_response
+		 * @param object $response
+		 * @param object $schema
+		 * @param string $operation_name
+		 * @param string $request
+		 * @param array $variables
+		 */
+		$include_in_response = apply_filters( 'graphql_query_log_include_in_response', true, $response, $schema, $operation_name, $request, $variables );
+
+		if ( true !== $include_in_response ) {
+			return $response;
+		}
 
 		if ( ! empty( $response ) ) {
 			if( is_array( $response ) ) {

--- a/src/Tracing.php
+++ b/src/Tracing.php
@@ -293,25 +293,10 @@ class Tracing {
 		/**
 		 * If tracing should be included in the response
 		 */
-		if ( is_array( $response ) ) {
-			foreach ( $response as $key => $res ) {
-				/**
-				 * Only include the trace data once per request
-				 */
-				if ( 0 !== $key ) {
-					return false;
-				}
-				if ( true === self::include_tracing_in_response( $res, $schema, $operation_name, $request, $variables ) ) {
-					if ( is_object( $res ) ) {
-						$res->extensions['tracing'] = self::get_trace( $key );
-					} else if ( is_array( $res ) ) {
-						$res['extensions']['tracing'] = self::get_trace( $key );
-					}
-				}
-				$response[ $key ] = $res;
-			}
-		} else {
-			if ( true === self::include_tracing_in_response( $response, $schema, $operation_name, $request, $variables ) ) {
+		if ( ! empty( $response ) ) {
+			if( is_array( $response ) ) {
+				$response['extensions']['tracing'] = self::get_trace();
+			} else if ( is_object( $response ) ) {
 				$response->extensions['tracing'] = self::get_trace();
 			}
 		}
@@ -335,25 +320,11 @@ class Tracing {
 	 */
 	public static function add_tracked_queries_to_response_extensions( $response, $schema, $operation_name, $request, $variables ) {
 
-		if ( is_array( $response ) ) {
-			foreach( $response as $key => $res ) {
-				/**
-				 * Only include the trace data once per request
-				 */
-				if ( 0 !== $key ) {
-					return false;
-				}
-				if ( true === self::include_tracing_in_response( $res, $schema, $operation_name, $request, $variables ) ) {
-					if ( is_object( $res ) ) {
-						$res->extensions['queryLog'] = QueryTrace::get_trace( $key );
-					} else if ( is_array( $res ) ) {
-						$res['extensions']['queryLog'] = QueryTrace::get_trace( $key );
-					}
-				}
-				$response[ $key ] = $res;
-			}
-		} else {
-			if ( true === self::include_tracing_in_response( $response, $schema, $operation_name, $request, $variables ) ) {
+
+		if ( ! empty( $response ) ) {
+			if( is_array( $response ) ) {
+				$response['extensions']['queryLog'] = QueryTrace::get_trace();
+			} else if ( is_object( $response ) ) {
 				$response->extensions['queryLog'] = QueryTrace::get_trace();
 			}
 		}

--- a/wp-graphql-insights.php
+++ b/wp-graphql-insights.php
@@ -199,6 +199,13 @@ if ( ! class_exists( '\WPGraphQL\Extensions\Insights' ) ) {
 function graphql_insights_init() {
 
 	/**
+	 * If SAVEQUERIES hasn't already been defined, define it now
+	 */
+	if ( ! defined( 'SAVEQUERIES' ) && true === apply_filters( 'wpgraphql_insights_track_queries', true ) ) {
+		define( 'SAVEQUERIES', true );
+	}
+
+	/**
 	 * If the version of WPGraphQL isn't up to date, don't instantiate tracing as it won't work properly
 	 * @todo: consider displaying an Admin Notice or something to that tune if the versions aren't compatible
 	 */


### PR DESCRIPTION
This updates WPGraphQL Insights to work with WPGraphQL's new Request class that's coming soon. 

The notable changes are: 
https://github.com/wp-graphql/wp-graphql-insights/compare/feature/update-to-work-with-wpgraphql-0.3.0?expand=1#diff-c376ccefb8bee361e3fbd8f55f83cdfbR274

and:
https://github.com/wp-graphql/wp-graphql-insights/compare/feature/update-to-work-with-wpgraphql-0.3.0?expand=1#diff-c376ccefb8bee361e3fbd8f55f83cdfbR317

The other changes are just general cleanup and organization while i was in here. 