### PR TITLE
fix typo

### DIFF
--- a/wp-graphql-insights.php
+++ b/wp-graphql-insights.php
@@ -208,7 +208,7 @@ function graphql_insights_init() {
 	$graphql_insights_default_capability = apply_filters( 'graphql_insights_default_capability', 'manage_options' );
 
 	/**
-	 * If GRAPQHL_DEBUG is enabled or the request is authenticated by a user with , enable Insights
+	 * If GRAPHQL_DEBUG is enabled or the request is authenticated by a user with , enable Insights
 	 */
 	if ( defined( 'GRAPHQL_DEBUG' ) && true === GRAPHQL_DEBUG || current_user_can( $graphql_insights_default_capability ) ) {
 		$graphql_insights_active = true;

--- a/wp-graphql-insights.php
+++ b/wp-graphql-insights.php
@@ -210,7 +210,7 @@ function graphql_insights_init() {
 	/**
 	 * If GRAPQHL_DEBUG is enabled or the request is authenticated by a user with , enable Insights
 	 */
-	if ( defined( 'GRAPQHL_DEBUG' ) && true === GRAPHQL_DEBUG || current_user_can( $graphql_insights_default_capability ) ) {
+	if ( defined( 'GRAPHQL_DEBUG' ) && true === GRAPHQL_DEBUG || current_user_can( $graphql_insights_default_capability ) ) {
 		$graphql_insights_active = true;
 	}
 


### PR DESCRIPTION
There is a small typo `GRAPQHL_DEBUG`instead of `GRAPHQL_DEBUG`.
As a result, we need to define both `GRAPQHL_DEBUG` and `GRAPHQL_DEBUG`to activate insights without an authenticated user.